### PR TITLE
Add output format query parameter and AsRef impl to Speech

### DIFF
--- a/src/api/history.rs
+++ b/src/api/history.rs
@@ -34,7 +34,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn history_items_delete_is_deleting_that_history_item() {
-        let _speech = Speech::new("test", "Adam", "eleven_monolingual_v1", 4)
+        let _speech = Speech::new("test", "Adam", "eleven_monolingual_v1", 4, None)
             .await
             .unwrap();
 

--- a/src/api/tts.rs
+++ b/src/api/tts.rs
@@ -176,6 +176,12 @@ impl Speech {
     }
 }
 
+impl AsRef<[u8]> for Speech {
+    fn as_ref(&self) -> &[u8] {
+        self.audio.as_ref()
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 struct TTSBody {
     text: String,


### PR DESCRIPTION
This PR adds an additional parameter to the `Speech::new` and `Speech::from_file` functions: `format`. This parameter is an enum of type `OutputFormat`, each of which represents a different possible format the elevenlabs api can return as a response (see [here](https://help.elevenlabs.io/hc/en-us/articles/15754340124305-What-audio-formats-do-you-support) for a full list). Passing `None` into the parameter just omits the "output_format" query argument.

It also adds an `AsRef` impl to `Speech` that returns a byte slice of the internal audio. With this, the user can do whatever they please with the returned speech rather than just play/save it.