### PR TITLE
Allow end user to use vendored, or rustls for reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ repository = "https://github.com/rwxbytes/elevenlabs_rs"
 keywords = ["elevenlabs", "tts", "text-to-speech", "voice-clone", "ai"]
 
 exclude = [
-    ".idea",
-    "/src/endpoints/conversational_ai.rs",
-    "/src/utils/audio_helpers.rs",
-    "/src/convai_client.rs",
+  ".idea",
+  "/src/endpoints/conversational_ai.rs",
+  "/src/utils/audio_helpers.rs",
+  "/src/convai_client.rs",
 ]
 
 
@@ -34,12 +34,25 @@ tokio-tungstenite = { version = "0.23.0", features = ["native-tls"] }
 [features]
 default = ["playback"]
 playback = ["dep:rodio"]
+# Enable rustls for TLS support
+rustls = ["reqwest/rustls-tls-native-roots"]
+# Enable rustls and webpki-roots
+rustls-webpki-roots = ["reqwest/rustls-tls-webpki-roots"]
+# Enable native-tls for TLS support
+native-tls = ["reqwest/native-tls"]
+# Remove dependency on OpenSSL
+native-tls-vendored = ["reqwest/native-tls-vendored"]
 
 [dev-dependencies]
 twilio = "1.1.0"
 axum = { version = "0.7.5", features = ["ws"] }
 async-openai = "0.23.3"
-dasp = { version = "0.11.0", features = ["signal", "interpolate-linear", "interpolate", "slice"] }
+dasp = { version = "0.11.0", features = [
+  "signal",
+  "interpolate-linear",
+  "interpolate",
+  "slice",
+] }
 cpal = "0.15.3"
 tokio-stream = "0.1.16"
 bytemuck = "1.16.0"
@@ -64,4 +77,3 @@ path = "examples/pronunciation_dictionaries.rs"
 [[example]]
 name = "twilio_openai"
 path = "examples/twilio_openai.rs"
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,11 @@ base64 = "0.22.1"
 bytes = "1.4.0"
 futures-channel = "0.3.30"
 futures-util = "0.3.28"
-reqwest = { version = "0.12.5", features = ["stream", "json", "multipart"] }
+reqwest = { version = "0.12.5", features = [
+  "stream",
+  "json",
+  "multipart",
+], default-features = false }
 rodio = { version = "0.17.1", optional = true }
 serde = { version = "1.0.173", features = ["derive"] }
 serde_json = "1.0.103"
@@ -32,8 +36,14 @@ tokio = { version = "1.29.1", features = ["full"] }
 tokio-tungstenite = { version = "0.23.0", features = ["native-tls"] }
 
 [features]
-default = ["playback"]
+default = ["playback", "default-reqwest"]
 playback = ["dep:rodio"]
+default-reqwest = [
+  "reqwest/default-tls",
+  "reqwest/charset",
+  "reqwest/http2",
+  "reqwest/macos-system-configuration",
+]
 # Enable rustls for TLS support
 rustls = ["reqwest/rustls-tls-native-roots"]
 # Enable rustls and webpki-roots


### PR DESCRIPTION
The default TLS library for reqwest is native ssl. On some use case, rustls might be more convenient.

This PR will allow the library user to use reqwest with rustls or vendored openssl instead.