### PR TITLE
Fix deserialization error when the transcript contains non-word audio events rather than actual words

### DIFF
--- a/elevenlabs_rs/src/endpoints/genai/speech_to_text.rs
+++ b/elevenlabs_rs/src/endpoints/genai/speech_to_text.rs
@@ -329,7 +329,7 @@ pub struct Word {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum WordType {
     Word,
     Spacing,


### PR DESCRIPTION
Came across this bug while testing the library out for an AI agent's STT for incoming audio and speaking gibberish into the microphone, elevenlabs_rs uniformly returned an error saying that it was failing to parse the response body from the create transcript endpoint while speaking normally returned an acceptable output. Investigation showed that the "AudioEvent" variant of `WordType` was being serialized in snake_case, not spacelesslowercase as the library expected.
Before:
<img width="808" height="186" alt="image" src="https://github.com/user-attachments/assets/a9a78d4b-8231-46e1-b7a4-f5f23c20f006" />

After:
<img width="788" height="385" alt="image" src="https://github.com/user-attachments/assets/acaadc27-fbe2-440a-a6b4-f310feeee484" />
