### PR TITLE
Feature-gate WebSocket TLS + bump reqwest 0.13 / tokio-tungstenite 0.29 / thiserror 2

### DIFF
--- a/elevenlabs_rs/Cargo.toml
+++ b/elevenlabs_rs/Cargo.toml
@@ -15,7 +15,7 @@ base64 = "0.22.1"
 bytes = "1.9.0"
 futures-channel = "0.3.30"
 futures-util = "0.3.28"
-reqwest = { version = "0.12.5", features = [
+reqwest = { version = "0.13", features = [
   "stream",
   "json",
   "multipart",
@@ -24,16 +24,16 @@ rodio = { version = "0.17.1", optional = true }
 serde = { version = "1.0.173", features = ["derive"] }
 serde_json = "1.0.103"
 strum = { version = "0.26.3", features = ["derive"] }
-thiserror = "1.0.43"
+thiserror = "2"
 tokio = { version = "1.29.1", features = ["full"] }
-tokio-tungstenite = { version = "0.23.0", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.29" }
 
 [features]
 default = [
   "admin",
   "genai",
   "playback",
-  "reqwest/default-tls",
+  "reqwest/native-tls",
   "tokio-tungstenite/native-tls",
 ]
 playback = ["dep:rodio"]
@@ -42,11 +42,11 @@ convai = []
 genai = []
 ws = []
 # Enable rustls for TLS support
-rustls = ["reqwest/rustls-tls-native-roots", "tokio-tungstenite/rustls"]
+rustls = ["reqwest/rustls", "tokio-tungstenite/rustls-tls-native-roots"]
 # Enable rustls and webpki-roots
 rustls-webpki-roots = [
-  "reqwest/rustls-tls-webpki-roots",
-  "tokio-tungstenite/rustls",
+  "reqwest/rustls",
+  "tokio-tungstenite/rustls-tls-webpki-roots",
 ]
 # Enable native-tls for TLS support
 native-tls = ["reqwest/native-tls", "tokio-tungstenite/native-tls"]

--- a/elevenlabs_rs/src/client.rs
+++ b/elevenlabs_rs/src/client.rs
@@ -847,7 +847,7 @@ mod tests {
             let server = tokio::spawn(async move {
                 let (stream, _) = listener.accept().await.unwrap();
                 let mut ws = accept_async(stream).await.unwrap();
-                ws.send(Message::Ping(vec![1, 2, 3])).await.unwrap();
+                ws.send(Message::Ping(vec![1, 2, 3].into())).await.unwrap();
                 ws.send(Message::Text(
                     r#"{"message_type":"partial_transcript","text":"hello"}"#.into(),
                 ))
@@ -930,7 +930,7 @@ mod tests {
             let server = tokio::spawn(async move {
                 let (stream, _) = listener.accept().await.unwrap();
                 let mut ws = accept_async(stream).await.unwrap();
-                ws.send(Message::Text(server_payload)).await.unwrap();
+                ws.send(Message::Text(server_payload.into())).await.unwrap();
             });
 
             let endpoint = RealtimeSpeechToText::new(

--- a/elevenlabs_rs/src/endpoints/genai/tts.rs
+++ b/elevenlabs_rs/src/endpoints/genai/tts.rs
@@ -904,7 +904,7 @@ pub mod ws {
         }
         pub fn to_message(&self) -> Result<Message> {
             let json = serde_json::to_string(&self)?;
-            Ok(Message::Text(json))
+            Ok(Message::Text(json.into()))
         }
     }
 

--- a/elevenlabs_rs/src/ws.rs
+++ b/elevenlabs_rs/src/ws.rs
@@ -111,9 +111,11 @@ where
     type Output = O;
 
     fn encode(input: Self::Input, context: WebSocketErrorContext) -> Result<Message> {
-        Ok(Message::Text(serde_json::to_string(&input).map_err(
-            |source| WebSocketError::Encode { context, source },
-        )?))
+        Ok(Message::Text(
+            serde_json::to_string(&input)
+                .map_err(|source| WebSocketError::Encode { context, source })?
+                .into(),
+        ))
     }
 
     fn decode(message: Message, context: WebSocketErrorContext) -> Result<Option<Self::Output>> {
@@ -582,7 +584,7 @@ where
 }
 
 async fn handle_close_frame<T>(
-    msg: Option<tokio_tungstenite::tungstenite::protocol::CloseFrame<'_>>,
+    msg: Option<tokio_tungstenite::tungstenite::protocol::CloseFrame>,
     tx: &mpsc::Sender<Result<T>>,
     context: WebSocketErrorContext,
 ) -> Result<()> {


### PR DESCRIPTION
The base `tokio-tungstenite` dependency hard-enabled `native-tls`, so the existing `rustls` feature couldn't actually drop OpenSSL (native-tls leaked in regardless, since Cargo features are additive). This removes the hardcoded native-tls from the base dep, leaving TLS selected purely via the `native-tls`/`rustls` features (`default` still native-tls). Also bumps reqwest 0.12→0.13, tokio-tungstenite 0.23→0.29 (Message payloads are now Utf8Bytes/Bytes), and thiserror 1→2. Public API unchanged.